### PR TITLE
Added Modern C++ Date & Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Current implementations:
   - Various methods (Date & Time)
 - Ocaml
   - Simple method (Date)
-- Perl
-  - Simple method (Date & Time)
 - PHP
   - Various methods (Date & Time)
 - Powershell

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Current implementations:
   - Various methods (Date & Time)
 - Ocaml
   - Simple method (Date)
+- Perl
+  - Simple method (Date & Time)
 - PHP
   - Various methods (Date & Time)
 - Powershell

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Current implementations:
   - Simple method (Date & Time)
 - C++
   - Simple method (Date)
+  - Modern C++ method (Date & Time)
 - C#
   - Simple method (Date & Time)
 - Dart

--- a/cplusplus/chrono.cpp
+++ b/cplusplus/chrono.cpp
@@ -1,0 +1,14 @@
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+int main() {
+  using clk = std::chrono::system_clock;
+  auto now = clk::to_time_t(clk::now());
+
+  std::cout << "Date and time: "
+            << std::put_time(std::localtime(&now), "%Y-%m-%d %H:%M:%S")
+            << std::endl;
+
+  return 0;
+}

--- a/perl/datetime.pl
+++ b/perl/datetime.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/env perl
+use v5.10;
+use warnings;
+
+use Time::Piece; # Core module since 5.10
+
+my $t = localtime;
+say $t->ymd . ' ' . $t->hms;

--- a/perl/datetime.pl
+++ b/perl/datetime.pl
@@ -1,8 +1,0 @@
-#!/usr/bin/env perl
-use v5.10;
-use warnings;
-
-use Time::Piece; # Core module since 5.10
-
-my $t = localtime;
-say $t->ymd . ' ' . $t->hms;


### PR DESCRIPTION
The current C++ implementation uses the old c-style `std::time()` function. 
Since C++11 it is advised to use the std::chrono library when working on some kind of time-related issue.

As a bonus, this method supplies time as well which the current one does not.