### PR TITLE
Added simple Perl Date & Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Current implementations:
   - Various methods (Date & Time)
 - Powershell
   - Simple method (Date & Time, UTC and Local)
+- Perl
+  - Simple method (Date & Time)
 - Python
   - Various methods (Date)
   - Simple method (Date & Time)

--- a/perl/datetime.pl
+++ b/perl/datetime.pl
@@ -1,0 +1,7 @@
+use v5.10;
+use warnings;
+
+use Time::Piece;
+
+my $t = localtime;
+say $t->ymd . ' ' . $t->hms


### PR DESCRIPTION
Writes the date and time in an ISO 8601 compatible extended format using ISO 8601:2004(E)'s note in section 4.3.2, which allows the omission of the separator `T` character.